### PR TITLE
Small changes

### DIFF
--- a/StepDialog.py
+++ b/StepDialog.py
@@ -103,7 +103,7 @@ class StepDialog(QtGui.QDialog):
         
         # Size
         self.comboSize = QtGui.QComboBox(self.algInstructionsEditBar)
-        self.comboSize.setMaximumWidth(35)
+        self.comboSize.setMaximumWidth(45)
         self.algInstructionsEditBar.addWidget(self.comboSize)
         self.comboSize.setEditable(True)
         db = QtGui.QFontDatabase()
@@ -158,11 +158,12 @@ class StepDialog(QtGui.QDialog):
         self.batchModeDialog.connect(self.batchModeDialog, QtCore.SIGNAL("finished(int)"), self.forward)    
         
         if self.alg.provider.getName() == "workflowtools" and self.alg.name == "Workflow instructions":
-            self.resize(1120, 790)
             cols = 0
         else:
             cols = 1
-        self.algInstructionsText.setMinimumWidth(250)
+            self.tabLayout.setColumnStretch(1,1)
+        self.resize(1120, 790)
+        self.algInstructionsText.setMinimumWidth(350)
         self.tabLayout.addWidget(self.algInstructionsWidget,0,0)
         self.tabLayout.addWidget(self.normalModeDialog, 0, 1)
         self.tabLayout.addWidget(self.batchModeDialog, 0, 1)
@@ -265,7 +266,7 @@ class StepDialog(QtGui.QDialog):
     
     def setInstructions(self, instructions):
         self.algInstructionsText.setText(instructions)
-    
+
     # not used for now    
     def addRasterInputs(self, inputs):
         if self.getMode() == NORMAL_MODE:

--- a/StepDialog.py
+++ b/StepDialog.py
@@ -269,6 +269,26 @@ class StepDialog(QtGui.QDialog):
         self.algInstructionsText.setText(instructions)
         self.algInstructionsText.document().setMetaInformation(QtGui.QTextDocument.DocumentUrl, "file:" + self.workflowBaseDir +'/')
     
+    # Disconnect all the signals from nomalModeDialog and batchModeDialog when
+    # StepDialog is being closed
+    def closeEvent(self, evt):
+        self.normalModeDialog.disconnect(self.normalModeDialog, QtCore.SIGNAL("finished(int)"), self.forward)
+        self.batchModeDialog.disconnect(self.batchModeDialog, QtCore.SIGNAL("finished(int)"), self.forward)
+        # batchModeDialog could be already closed if the algorithm was executed
+        # in batch mode
+        try:
+            self.batchModeDialog.closeEvent(evt)
+        except TypeError:
+            pass
+        # normalModeDialog could be already closed if the algorithm was executed
+        # in normal mode
+        try:
+            self.normalModeDialog.closeEvent(evt)
+        except TypeError:
+            pass
+        QtGui.QDialog.closeEvent(self, evt)
+            
+    
     # not used for now    
     def addRasterInputs(self, inputs):
         if self.getMode() == NORMAL_MODE:

--- a/StepDialog.py
+++ b/StepDialog.py
@@ -40,10 +40,11 @@ BATCH_MODE = "Batch"
 # box and option to change from normal to batch mode if the dialog is editable.
 class StepDialog(QtGui.QDialog):
     
-    def __init__(self, alg, mainDialog, canEdit=True):
+    def __init__(self, alg, mainDialog, workflowBaseDir, canEdit=True):
         
         self.alg = alg
         self.mainDialog = mainDialog
+        self.workflowBaseDir = workflowBaseDir
         self.goForward = False
         self.goBackward = False
         
@@ -266,7 +267,8 @@ class StepDialog(QtGui.QDialog):
     
     def setInstructions(self, instructions):
         self.algInstructionsText.setText(instructions)
-
+        self.algInstructionsText.document().setMetaInformation(QtGui.QTextDocument.DocumentUrl, "file:" + self.workflowBaseDir +'/')
+    
     # not used for now    
     def addRasterInputs(self, inputs):
         if self.getMode() == NORMAL_MODE:

--- a/Workflow.py
+++ b/Workflow.py
@@ -140,9 +140,9 @@ class Workflow(GeoAlgorithm):
         else:
             GrassUtils.endGrassSession() 
         self.setStepParameters(step)    
-        stepDialog = StepDialog(step['algorithm'], None, False)
-        stepDialog.setMode(step['mode'])
-        stepDialog.setInstructions(step['instructions'])
+        stepDialog = StepDialog(step['algorithm'], None, os.path.dirname(self.descriptionFile), False)
+        stepDialog.setMode(step['mode']) 
+        stepDialog.setInstructions(step['instructions']) 
         stepDialog.setWindowTitle("WOIS Workflow " + unicode(self.name) + ", Step "+unicode(self._steps.index(step)+1)+" of "+unicode(len(self._steps))+": "+step['algorithm'].name)
         stepDialog.setWindowIcon(self.getIcon())
         # set as window modal to allow access to QGIS functions

--- a/WorkflowCreatorDialog.py
+++ b/WorkflowCreatorDialog.py
@@ -28,6 +28,7 @@
 
 from PyQt4 import QtCore, QtGui
 import codecs
+import os
 from processing.core.Processing import Processing
 from processing.core.parameters import ParameterString
 from processing.core.parameters import ParameterBoolean
@@ -232,7 +233,7 @@ class WorkflowCreatorDialog(AlgorithmDialogBase):
                 self.canvasTabWidget.clear()
                 for i in range(0, self.workflow.getLength()):
                     # create a dialog for this algorithm
-                    stepDialog = StepDialog(self.workflow.getAlgorithm(i), self)      
+                    stepDialog = StepDialog(self.workflow.getAlgorithm(i), self, os.path.dirname(filename))      
                     stepDialog.setMode(self.workflow.getMode(i))
                     stepDialog.setInstructions(self.workflow.getInstructions(i))
                     # create new tab for it
@@ -260,7 +261,7 @@ class WorkflowCreatorDialog(AlgorithmDialogBase):
             alg = alg.getCopy()#copy.deepcopy(alg)
             
             # create a tab for this algorithm
-            stepDialog = StepDialog(alg, self)      
+            stepDialog = StepDialog(alg, self, "")      
             self.canvasTabWidget.addTab(stepDialog, alg.name)
             
             # add this step to the workflow 


### PR DESCRIPTION
The first commit ensures that all workflow steps have the same dimensions. It was looking a bit chaotic before.

The second commit makes it possible to add images to workflow instructions steps, e.g:
![screenshot](https://cloud.githubusercontent.com/assets/4759850/15074129/9b352e22-139d-11e6-98e6-e90ea349de7c.png)

The last commit should fix the issue mentioned by @ctottrup in a previous email.
